### PR TITLE
chore: adopt Spring Boot @AutoConfiguration and modernize core auto-configs

### DIFF
--- a/core/camel-spring-boot-xml/src/main/java/org/apache/camel/spring/boot/xml/CamelXmlAutoConfiguration.java
+++ b/core/camel-spring-boot-xml/src/main/java/org/apache/camel/spring/boot/xml/CamelXmlAutoConfiguration.java
@@ -20,16 +20,14 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.spring.boot.TypeConversionConfiguration;
 import org.apache.camel.spring.xml.XmlCamelContextConfigurer;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(before = CamelAutoConfiguration.class)
 @Import(TypeConversionConfiguration.class)
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-@AutoConfigureBefore(CamelAutoConfiguration.class)
 public class CamelXmlAutoConfiguration {
 
     /**

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java
@@ -65,14 +65,13 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.context.annotation.Lazy;
@@ -83,7 +82,7 @@ import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @EnableConfigurationProperties({CamelConfigurationProperties.class, CamelStartupConditionConfigurationProperties.class, PropertiesComponentConfiguration.class})
 @Import(TypeConversionConfiguration.class)
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
@@ -251,30 +250,28 @@ public class CamelAutoConfiguration {
     }
 
     static void configureDebugger(ApplicationContext applicationContext, CamelContext camelContext) {
-        try {
-            DebuggerConfigurationProperties debug = applicationContext.getBean(DebuggerConfigurationProperties.class);
-            DefaultConfigurationConfigurer.configureBacklogDebugger(camelContext, debug);
-        } catch (BeansException e) {
-            // optional so ignore
-        } catch (Exception e) {
-            throw RuntimeCamelException.wrapRuntimeException(e);
-        }
+        applicationContext.getBeanProvider(DebuggerConfigurationProperties.class).ifAvailable(debug -> {
+            try {
+                DefaultConfigurationConfigurer.configureBacklogDebugger(camelContext, debug);
+            } catch (Exception e) {
+                throw RuntimeCamelException.wrapRuntimeException(e);
+            }
+        });
     }
 
     static void configureCliConnector(ApplicationContext applicationContext, CamelContext camelContext) {
         // factory is bound eager into spring bean registry
-        try {
-            CliConnectorFactory ccf = applicationContext.getBean(CliConnectorFactory.class);
-            CliConnector connector = ccf.createConnector();
-            camelContext.addService(connector, true);
-            // force start cli connector early as otherwise it will be deferred until context is started
-            // but, we want status available during startup phase
-            ServiceHelper.startService(connector);
-        } catch (BeansException e) {
-            // optional so ignore
-        } catch (Exception e) {
-            throw RuntimeCamelException.wrapRuntimeException(e);
-        }
+        applicationContext.getBeanProvider(CliConnectorFactory.class).ifAvailable(ccf -> {
+            try {
+                CliConnector connector = ccf.createConnector();
+                camelContext.addService(connector, true);
+                // force start cli connector early as otherwise it will be deferred until context is started
+                // but, we want status available during startup phase
+                ServiceHelper.startService(connector);
+            } catch (Exception e) {
+                throw RuntimeCamelException.wrapRuntimeException(e);
+            }
+        });
     }
 
     static void configureStartupRecorder(CamelContext camelContext, CamelConfigurationProperties config) {

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/console/CamelDevConsoleAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/console/CamelDevConsoleAutoConfiguration.java
@@ -20,20 +20,18 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.spring.boot.actuate.endpoint.CamelRouteControllerEndpoint;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /*
  * Auto configuration for the {@link CamelDevConsoleEndpoint}.
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnClass(name = "org.apache.camel.impl.console.DefaultDevConsoleRegistry")
 @ConditionalOnBean(CamelAutoConfiguration.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelDevConsoleAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRouteControllerEndpointAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRouteControllerEndpointAutoConfiguration.java
@@ -19,20 +19,18 @@ package org.apache.camel.spring.boot.actuate.endpoint;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /*
  * Auto configuration for the {@link CamelRouteControllerEndpoint}.
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnAvailableEndpoint(endpoint = CamelRouteControllerEndpoint.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelRouteControllerEndpointAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpoint.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpoint.java
@@ -122,7 +122,7 @@ public class CamelRoutesEndpoint {
     }
 
     private Route getRoute(String id){
-        return getRoutes().stream().filter(x->x.getId().equals(id)).findAny().get();
+        return getRoutes().stream().filter(x->x.getId().equals(id)).findAny().orElse(null);
     }
 
     private Collection<Route> getRoutes(){

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpointAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/endpoint/CamelRoutesEndpointAutoConfiguration.java
@@ -19,22 +19,20 @@ package org.apache.camel.spring.boot.actuate.endpoint;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /*
  * Auto configuration for the {@link CamelRoutesEndpoint}.
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @EnableConfigurationProperties({ CamelRoutesEndpointProperties.class })
 @ConditionalOnAvailableEndpoint(endpoint = CamelRoutesEndpoint.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelRoutesEndpointAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/AsyncHealthIndicatorAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/AsyncHealthIndicatorAutoConfiguration.java
@@ -21,12 +21,12 @@ import org.apache.camel.spring.boot.actuate.health.readiness.CamelReadinessState
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthContributors;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.boot.health.registry.HealthContributorRegistry;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -41,7 +41,7 @@ import java.time.ZonedDateTime;
  *
  * TODO: To be refactored once async health contributors feature will be added in spring boot.
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnProperty(prefix = "camel.health", name = "async-camel-health-check", havingValue = "true")
 public class AsyncHealthIndicatorAutoConfiguration implements InitializingBean {
     private static final Logger log = LoggerFactory.getLogger(AsyncHealthIndicatorAutoConfiguration.class);
@@ -90,7 +90,7 @@ public class AsyncHealthIndicatorAutoConfiguration implements InitializingBean {
 
         private HealthIndicator wrappedHealthIndicator;
 
-        private Health lastHealth;
+        private volatile Health lastHealth;
 
         public WrappedHealthIndicator(HealthIndicator wrappedHealthIndicator) {
             this.wrappedHealthIndicator = wrappedHealthIndicator;

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/CamelAvailabilityCheckAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/CamelAvailabilityCheckAutoConfiguration.java
@@ -21,28 +21,29 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.spring.boot.actuate.health.liveness.CamelLivenessStateHealthIndicator;
 import org.apache.camel.spring.boot.actuate.health.readiness.CamelReadinessStateHealthIndicator;
 
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.availability.ApplicationAvailabilityAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.availability.ApplicationAvailability;
 import org.springframework.boot.health.application.LivenessStateHealthIndicator;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter({ CamelAutoConfiguration.class, ApplicationAvailabilityAutoConfiguration.class })
+@AutoConfiguration(after = { CamelAutoConfiguration.class, ApplicationAvailabilityAutoConfiguration.class })
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @ConditionalOnClass(LivenessStateHealthIndicator.class)
 public class CamelAvailabilityCheckAutoConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public CamelLivenessStateHealthIndicator camelLivenessStateHealthIndicator(
             ApplicationAvailability applicationAvailability, CamelContext camelContext) {
         return new CamelLivenessStateHealthIndicator(applicationAvailability, camelContext);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public CamelReadinessStateHealthIndicator camelReadinessStateHealthIndicator(
             ApplicationAvailability applicationAvailability, CamelContext camelContext) {
         return new CamelReadinessStateHealthIndicator(applicationAvailability, camelContext);

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/CamelHealthCheckAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/health/CamelHealthCheckAutoConfiguration.java
@@ -23,123 +23,110 @@ import org.apache.camel.health.HealthCheckRepository;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnClass({ HealthIndicator.class })
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(CamelHealthCheckConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelHealthCheckAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(CamelHealthCheckAutoConfiguration.class);
 
-    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+    @Bean(name = "camelHealth")
     @ConditionalOnClass({ CamelContext.class })
     @ConditionalOnMissingBean(CamelHealthCheckIndicator.class)
-    protected class CamelHealthCheckIndicatorInitializer {
+    @ConditionalOnProperty(prefix = "camel.health", name = "enabled", matchIfMissing = true)
+    public HealthIndicator camelHealthCheckIndicator(ApplicationContext applicationContext,
+            CamelContext camelContext, CamelHealthCheckConfigurationProperties config) {
 
-        @Bean(name = "camelHealth")
-        public HealthIndicator camelHealthCheckIndicator(ApplicationContext applicationContext,
-                CamelContext camelContext, CamelHealthCheckConfigurationProperties config) {
-            if (config != null && config.getEnabled() != null && !config.getEnabled()) {
-                // health check is disabled
-                return null;
+        // auto-detect camel-health on classpath
+        HealthCheckRegistry hcr = camelContext.getCamelContextExtension()
+                .getContextPlugin(HealthCheckRegistry.class);
+        if (hcr == null) {
+            if (config.getEnabled() != null && config.getEnabled()) {
+                LOG.warn("Cannot find HealthCheckRegistry from classpath. Add camel-health to classpath.");
             }
-            if (config == null) {
-                config = new CamelHealthCheckConfigurationProperties();
-            }
-
-            // auto-detect camel-health on classpath
-            HealthCheckRegistry hcr = camelContext.getCamelContextExtension()
-                    .getContextPlugin(HealthCheckRegistry.class);
-            if (hcr == null) {
-                if (config.getEnabled() != null && config.getEnabled()) {
-                    LOG.warn("Cannot find HealthCheckRegistry from classpath. Add camel-health to classpath.");
-                }
-                return null;
-            }
-            // lets signal we are integrated with spring boot
-            hcr.setId("camel-spring-boot");
-
-            if (config.getEnabled() != null) {
-                hcr.setEnabled(config.getEnabled());
-            }
-            if (config.getExcludePattern() != null) {
-                hcr.setExcludePattern(config.getExcludePattern());
-            }
-            if (config.getExposureLevel() != null) {
-                hcr.setExposureLevel(config.getExposureLevel());
-            }
-            if (config.getInitialState() != null) {
-                hcr.setInitialState(
-                        camelContext.getTypeConverter().convertTo(HealthCheck.State.class, config.getInitialState()));
-            }
-
-            // context is enabled by default
-            if (hcr.isEnabled()) {
-                HealthCheck hc = (HealthCheck) hcr.resolveById("context");
-                if (hc != null) {
-                    hcr.register(hc);
-                }
-            }
-            // routes are enabled by default
-            if (hcr.isEnabled()) {
-                HealthCheckRepository hc = hcr.getRepository("routes")
-                        .orElse((HealthCheckRepository) hcr.resolveById("routes"));
-                if (hc != null) {
-                    if (config.getRoutesEnabled() != null) {
-                        hc.setEnabled(config.getRoutesEnabled());
-                    }
-                    hcr.register(hc);
-                }
-            }
-            // producers are disabled by default
-            if (hcr.isEnabled()) {
-                HealthCheckRepository hc = hcr.getRepository("producers")
-                        .orElse((HealthCheckRepository) hcr.resolveById("producers"));
-                if (hc != null) {
-                    if (config.getProducersEnabled() != null) {
-                        hc.setEnabled(config.getProducersEnabled());
-                    }
-                    hcr.register(hc);
-                }
-            }
-            // consumers are enabled by default
-            if (hcr.isEnabled()) {
-                HealthCheckRepository hc = hcr.getRepository("consumers")
-                        .orElse((HealthCheckRepository) hcr.resolveById("consumers"));
-                if (hc != null) {
-                    if (config.getConsumersEnabled() != null) {
-                        hc.setEnabled(config.getConsumersEnabled());
-                    }
-                    hcr.register(hc);
-                }
-            }
-            // registry are enabled by default
-            if (hcr.isEnabled()) {
-                HealthCheckRepository hc = hcr.getRepository("registry")
-                        .orElse((HealthCheckRepository) hcr.resolveById("registry"));
-                if (hc != null) {
-                    if (config.getRegistryEnabled() != null) {
-                        hc.setEnabled(config.getRegistryEnabled());
-                    }
-                    hcr.register(hc);
-                }
-            }
-
-            return new CamelHealthCheckIndicator(applicationContext, camelContext, config.getExposureLevel());
+            return null;
         }
+        // lets signal we are integrated with spring boot
+        hcr.setId("camel-spring-boot");
+
+        if (config.getEnabled() != null) {
+            hcr.setEnabled(config.getEnabled());
+        }
+        if (config.getExcludePattern() != null) {
+            hcr.setExcludePattern(config.getExcludePattern());
+        }
+        if (config.getExposureLevel() != null) {
+            hcr.setExposureLevel(config.getExposureLevel());
+        }
+        if (config.getInitialState() != null) {
+            hcr.setInitialState(
+                    camelContext.getTypeConverter().convertTo(HealthCheck.State.class, config.getInitialState()));
+        }
+
+        // context is enabled by default
+        if (hcr.isEnabled()) {
+            HealthCheck hc = (HealthCheck) hcr.resolveById("context");
+            if (hc != null) {
+                hcr.register(hc);
+            }
+        }
+        // routes are enabled by default
+        if (hcr.isEnabled()) {
+            HealthCheckRepository hc = hcr.getRepository("routes")
+                    .orElse((HealthCheckRepository) hcr.resolveById("routes"));
+            if (hc != null) {
+                if (config.getRoutesEnabled() != null) {
+                    hc.setEnabled(config.getRoutesEnabled());
+                }
+                hcr.register(hc);
+            }
+        }
+        // producers are disabled by default
+        if (hcr.isEnabled()) {
+            HealthCheckRepository hc = hcr.getRepository("producers")
+                    .orElse((HealthCheckRepository) hcr.resolveById("producers"));
+            if (hc != null) {
+                if (config.getProducersEnabled() != null) {
+                    hc.setEnabled(config.getProducersEnabled());
+                }
+                hcr.register(hc);
+            }
+        }
+        // consumers are enabled by default
+        if (hcr.isEnabled()) {
+            HealthCheckRepository hc = hcr.getRepository("consumers")
+                    .orElse((HealthCheckRepository) hcr.resolveById("consumers"));
+            if (hc != null) {
+                if (config.getConsumersEnabled() != null) {
+                    hc.setEnabled(config.getConsumersEnabled());
+                }
+                hcr.register(hc);
+            }
+        }
+        // registry are enabled by default
+        if (hcr.isEnabled()) {
+            HealthCheckRepository hc = hcr.getRepository("registry")
+                    .orElse((HealthCheckRepository) hcr.resolveById("registry"));
+            if (hc != null) {
+                if (config.getRegistryEnabled() != null) {
+                    hc.setEnabled(config.getRegistryEnabled());
+                }
+                hcr.register(hc);
+            }
+        }
+
+        return new CamelHealthCheckIndicator(applicationContext, camelContext, config.getExposureLevel());
     }
 
 }

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/info/CamelInfoAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/actuate/info/CamelInfoAutoConfiguration.java
@@ -20,29 +20,23 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.info.ConditionalOnEnabledInfoContributor;
 import org.springframework.boot.actuate.info.InfoContributor;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnClass({ InfoContributor.class })
 @ConditionalOnBean(CamelAutoConfiguration.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelInfoAutoConfiguration {
 
+    @Bean
     @ConditionalOnClass({ CamelContext.class })
     @ConditionalOnMissingBean(CamelInfoContributor.class)
     @ConditionalOnEnabledInfoContributor(value = "camel")
-    protected static class CamelInfoContributorInitializer {
-
-        @Bean
-        public InfoContributor camelInfoContributor(CamelContext camelContext) {
-            return new CamelInfoContributor(camelContext);
-        }
-
+    public InfoContributor camelInfoContributor(CamelContext camelContext) {
+        return new CamelInfoContributor(camelContext);
     }
 
 }

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/cluster/ClusteredRouteControllerAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/cluster/ClusteredRouteControllerAutoConfiguration.java
@@ -17,8 +17,6 @@
 package org.apache.camel.spring.boot.cluster;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.camel.cluster.CamelClusterService;
@@ -29,38 +27,31 @@ import org.apache.camel.impl.cluster.ClusteredRouteFilters;
 import org.apache.camel.spi.RouteController;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.util.ObjectHelper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureBefore(CamelAutoConfiguration.class)
+@AutoConfiguration(before = CamelAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "camel.clustered.controller", name = "enabled")
 @EnableConfigurationProperties(ClusteredRouteControllerConfiguration.class)
 public class ClusteredRouteControllerAutoConfiguration {
 
-    @Autowired(required = false)
-    private List<ClusteredRouteFilter> filters = Collections.emptyList();
-
     @Bean
-    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
     @ConditionalOnMissingBean
     @ConditionalOnBean(CamelClusterService.class)
-    public RouteController routeController(ClusteredRouteControllerConfiguration configuration) {
+    public RouteController routeController(ClusteredRouteControllerConfiguration configuration,
+            ObjectProvider<ClusteredRouteFilter> filtersProvider) {
         ClusteredRouteController controller = new ClusteredRouteController();
         controller.setNamespace(configuration.getNamespace());
 
         Optional.ofNullable(configuration.getInitialDelay()).map(TimePatternConverter::toMilliSeconds)
                 .map(Duration::ofMillis).ifPresent(controller::setInitialDelay);
 
-        controller.setFilters(filters);
+        controller.setFilters(filtersProvider.orderedStream().toList());
         controller.addFilter(new ClusteredRouteFilters.IsAutoStartup());
 
         if (ObjectHelper.isNotEmpty(configuration.getClusterService())) {

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/routecontroller/SupervisingRouteControllerAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/routecontroller/SupervisingRouteControllerAutoConfiguration.java
@@ -20,16 +20,13 @@ import org.apache.camel.impl.engine.DefaultSupervisingRouteController;
 import org.apache.camel.spi.RouteController;
 import org.apache.camel.spi.SupervisingRouteController;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureBefore(CamelAutoConfiguration.class)
+@AutoConfiguration(before = CamelAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "camel.routecontroller", name = "enabled")
 @EnableConfigurationProperties(SupervisingRouteControllerConfiguration.class)
 public class SupervisingRouteControllerAutoConfiguration {

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/routetemplate/CamelRouteTemplateAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/routetemplate/CamelRouteTemplateAutoConfiguration.java
@@ -21,16 +21,14 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.main.PropertiesRouteTemplateParametersSource;
 import org.apache.camel.spi.RouteTemplateParameterSource;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(CamelRouteTemplateConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelRouteTemplateAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSSLAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/security/CamelSSLAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.support.jsse.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -34,11 +34,9 @@ import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @EnableConfigurationProperties(CamelSSLConfigurationProperties.class)
 public class CamelSSLAutoConfiguration {
 

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/threadpool/CamelThreadPoolAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/threadpool/CamelThreadPoolAutoConfiguration.java
@@ -20,16 +20,14 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.ThreadPoolProfileBuilder;
 import org.apache.camel.spi.ThreadPoolProfile;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(CamelThreadPoolConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelThreadPoolAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/trace/CamelTraceAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/trace/CamelTraceAutoConfiguration.java
@@ -19,16 +19,14 @@ package org.apache.camel.spring.boot.trace;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spi.BacklogTracer;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(CamelTraceConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CamelTraceAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/AwsVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/AwsVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.AwsVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(AwsVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class AwsVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/AzureVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/AzureVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.AzureVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(AzureVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class AzureVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/CyberArkVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/CyberArkVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.CyberArkVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(CyberArkVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class CyberArkVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/GcpVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/GcpVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.GcpVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(GcpVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class GcpVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/HashicorpVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/HashicorpVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.HashicorpVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(HashicorpVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class HashicorpVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/IBMVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/IBMVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.IBMSecretsManagerVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(IBMVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class IBMVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/KubernetesConfigMapVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/KubernetesConfigMapVaultAutoConfiguration.java
@@ -19,16 +19,14 @@ package org.apache.camel.spring.boot.vault;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.KubernetesConfigMapVaultConfiguration;
 import org.apache.camel.vault.KubernetesVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(KubernetesConfigMapVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class KubernetesConfigMapVaultAutoConfiguration {
 
     @Bean

--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/KubernetesVaultAutoConfiguration.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/vault/KubernetesVaultAutoConfiguration.java
@@ -18,16 +18,14 @@ package org.apache.camel.spring.boot.vault;
 
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.vault.KubernetesVaultConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = CamelAutoConfiguration.class)
 @ConditionalOnBean(CamelAutoConfiguration.class)
 @EnableConfigurationProperties(KubernetesVaultConfigurationProperties.class)
-@AutoConfigureAfter(CamelAutoConfiguration.class)
 public class KubernetesVaultAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
## Summary
- Migrate all 23 auto-configuration classes from `@Configuration(proxyBeanMethods = false)` + `@AutoConfigureAfter`/`@AutoConfigureBefore` to `@AutoConfiguration(after = ..., before = ...)`
- Fix thread safety in `AsyncHealthIndicatorAutoConfiguration` (`volatile` on `lastHealth`)
- Fix defensive coding in `CamelRoutesEndpoint` (`.orElse(null)` instead of `.get()`)
- Use `getBeanProvider().ifAvailable()` instead of try/catch `BeansException` in `CamelAutoConfiguration`
- Add `@ConditionalOnMissingBean` on liveness/readiness health indicators
- Flatten unnecessary inner classes in `CamelHealthCheckAutoConfiguration` and `CamelInfoAutoConfiguration`
- Replace `@Autowired` field injection with `ObjectProvider` parameter in `ClusteredRouteControllerAutoConfiguration`
- Remove redundant `@Scope(SCOPE_SINGLETON)`

## Test plan
- [ ] `mvn verify` on `core/camel-spring-boot`
- [ ] `mvn verify` on `core/camel-spring-boot-xml`
- [ ] Verify `AutoConfiguration.imports` files are unchanged